### PR TITLE
Make GitHub Actions check the future-8.x branch

### DIFF
--- a/.github/workflows/os_java_ci.yml
+++ b/.github/workflows/os_java_ci.yml
@@ -5,10 +5,10 @@ name: OptaPlanner CI
 on:
   push:
     branches:
-      - master
+      - future-8.x
   pull_request:
     branches:
-      - master
+      - future-8.x
 
 jobs:
   os-java:


### PR DESCRIPTION
@triceo Hopefully, this should make the OSxJDK matrix working on this branch of your fork.

We just need to make sure this commit won't appear in the master branch of the blessed optaplanner repository once we merge this branch there.