### PR TITLE
PLANNER-1993 Add JAXB marshalling for ConstructionHeuristic

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -93,6 +93,22 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+    </dependency>
+    <!-- TODO: replace by jakarta EE API? -->
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.constructionheuristic.decider.forager.ConstructionHeuristicForagerConfig;
 import org.optaplanner.core.config.constructionheuristic.placer.EntityPlacerConfig;
@@ -54,7 +53,6 @@ import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "ConstructionHeuristicType")
 @XStreamAlias("constructionHeuristic")
 public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHeuristicPhaseConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
@@ -22,6 +22,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.constructionheuristic.decider.forager.ConstructionHeuristicForagerConfig;
 import org.optaplanner.core.config.constructionheuristic.placer.EntityPlacerConfig;
 import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
@@ -31,6 +35,7 @@ import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
 import org.optaplanner.core.config.phase.PhaseConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;
@@ -49,6 +54,7 @@ import org.optaplanner.core.impl.solver.thread.ChildThreadType;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "ConstructionHeuristicType")
 @XStreamAlias("constructionHeuristic")
 public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHeuristicPhaseConfig> {
 
@@ -60,13 +66,24 @@ public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHe
     protected ValueSorterManner valueSorterManner = null;
 
     // TODO This is a List due to XStream limitations. With JAXB it could be just a EntityPlacerConfig instead.
+    @XmlElements({
+            @XmlElement(name = "queuedEntityPlacer", type = QueuedEntityPlacerConfig.class),
+            @XmlElement(name = "queuedValuePlacer", type = QueuedValuePlacerConfig.class),
+            @XmlElement(name = "pooledEntityPlacer", type = PooledEntityPlacerConfig.class)
+    })
     @XStreamImplicit
     protected List<EntityPlacerConfig> entityPlacerConfigList = null;
 
     /** Simpler alternative for {@link #entityPlacerConfigList}. */
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class)
+    })
     @XStreamImplicit()
     protected List<MoveSelectorConfig> moveSelectorConfigList = null;
 
+    @XmlElement(name = "forager")
     @XStreamAlias("forager")
     protected ConstructionHeuristicForagerConfig foragerConfig = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
@@ -17,12 +17,10 @@
 package org.optaplanner.core.config.constructionheuristic;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
 
-@XmlType(name = "ConstructionHeuristicTypeType") // TODO: think about XML type naming - TypeType
 @XmlEnum
 public enum ConstructionHeuristicType {
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,14 @@
 
 package org.optaplanner.core.config.constructionheuristic;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
 
+@XmlType(name = "ConstructionHeuristicTypeType") // TODO: think about XML type naming - TypeType
+@XmlEnum
 public enum ConstructionHeuristicType {
     /**
      * A specific form of {@link #ALLOCATE_ENTITY_FROM_QUEUE}.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
@@ -16,6 +16,8 @@
 
 package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.decider.forager.ConstructionHeuristicForager;
@@ -24,6 +26,7 @@ import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+@XmlType(name = "ConstructionHeuristicForagerType")
 @XStreamAlias("constructionHeuristicForager")
 public class ConstructionHeuristicForagerConfig extends AbstractConfig<ConstructionHeuristicForagerConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicForagerConfig.java
@@ -16,8 +16,6 @@
 
 package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
-import javax.xml.bind.annotation.XmlType;
-
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.decider.forager.ConstructionHeuristicForager;
@@ -26,7 +24,6 @@ import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-@XmlType(name = "ConstructionHeuristicForagerType")
 @XStreamAlias("constructionHeuristicForager")
 public class ConstructionHeuristicForagerConfig extends AbstractConfig<ConstructionHeuristicForagerConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicPickEarlyType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicPickEarlyType.java
@@ -17,9 +17,7 @@
 package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
-@XmlType(name = "ConstructionHeuristicPickEarlyTypeType") // TODO: think about XML type naming - TypeType
 @XmlEnum
 public enum ConstructionHeuristicPickEarlyType {
     NEVER,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicPickEarlyType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/ConstructionHeuristicPickEarlyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
 
 package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "ConstructionHeuristicPickEarlyTypeType") // TODO: think about XML type naming - TypeType
+@XmlEnum
 public enum ConstructionHeuristicPickEarlyType {
     NEVER,
     FIRST_NON_DETERIORATING_SCORE,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/decider/forager/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.constructionheuristic.decider.forager;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.constructionheuristic;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/EntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/EntityPlacerConfig.java
@@ -17,7 +17,6 @@
 package org.optaplanner.core.config.constructionheuristic.placer;
 
 import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.impl.constructionheuristic.placer.EntityPlacer;
@@ -28,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamInclude;
 /**
  * General superclass for {@link QueuedEntityPlacerConfig} and {@link PooledEntityPlacerConfig}.
  */
-@XmlType(name = "EntityPlacerType")
+
 @XmlSeeAlso({
         QueuedEntityPlacerConfig.class,
         QueuedValuePlacerConfig.class,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/EntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/EntityPlacerConfig.java
@@ -16,6 +16,9 @@
 
 package org.optaplanner.core.config.constructionheuristic.placer;
 
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.impl.constructionheuristic.placer.EntityPlacer;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
@@ -25,6 +28,12 @@ import com.thoughtworks.xstream.annotations.XStreamInclude;
 /**
  * General superclass for {@link QueuedEntityPlacerConfig} and {@link PooledEntityPlacerConfig}.
  */
+@XmlType(name = "EntityPlacerType")
+@XmlSeeAlso({
+        QueuedEntityPlacerConfig.class,
+        QueuedValuePlacerConfig.class,
+        PooledEntityPlacerConfig.class
+})
 @XStreamInclude({
         QueuedEntityPlacerConfig.class,
         QueuedValuePlacerConfig.class,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -21,6 +21,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -39,6 +43,7 @@ import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "PooledEntityPlacerType")
 @XStreamAlias("pooledEntityPlacer")
 public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPlacerConfig> {
 
@@ -78,6 +83,11 @@ public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPla
     }
 
     // TODO This is a List due to XStream limitations. With JAXB it could be just a MoveSelectorConfig instead.
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class)
+    })
     @XStreamImplicit()
     private List<MoveSelectorConfig> moveSelectorConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -43,7 +42,6 @@ import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "PooledEntityPlacerType")
 @XStreamAlias("pooledEntityPlacer")
 public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPlacerConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -44,7 +43,6 @@ import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "QueuedEntityPlacerType")
 @XStreamAlias("queuedEntityPlacer")
 public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPlacerConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
@@ -21,11 +21,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
@@ -39,6 +44,7 @@ import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "QueuedEntityPlacerType")
 @XStreamAlias("queuedEntityPlacer")
 public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPlacerConfig> {
 
@@ -74,8 +80,15 @@ public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPla
         return config;
     }
 
+    @XmlElement(name = "entitySelector")
     @XStreamAlias("entitySelector")
     protected EntitySelectorConfig entitySelectorConfig = null;
+
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class)
+    })
     @XStreamImplicit()
     protected List<MoveSelectorConfig> moveSelectorConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
@@ -19,6 +19,10 @@ package org.optaplanner.core.config.constructionheuristic.placer;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -40,6 +44,7 @@ import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "QueuedValuePlacerType")
 @XStreamAlias("queuedValuePlacer")
 public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlacerConfig> {
 
@@ -50,9 +55,17 @@ public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlace
     }
 
     protected Class<?> entityClass = null;
+
+    @XmlElement(name = "valueSelector")
     @XStreamAlias("valueSelector")
     protected ValueSelectorConfig valueSelectorConfig = null;
+
     // TODO This is a List due to XStream limitations. With JAXB it could be just a MoveSelectorConfig instead.
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class)
+    })
     @XStreamImplicit()
     private List<MoveSelectorConfig> moveSelectorConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
@@ -44,7 +43,6 @@ import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "QueuedValuePlacerType")
 @XStreamAlias("queuedValuePlacer")
 public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlacerConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.constructionheuristic.placer;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionCacheType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionCacheType.java
@@ -17,12 +17,11 @@
 package org.optaplanner.core.config.heuristic.selector.common;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 /**
  * There is no INHERIT by design because 2 sequential caches provides no benefit, only memory overhead.
  */
-@XmlType(name = "SelectionCacheTypeType") // TODO: think about XML type naming - TypeType
+
 @XmlEnum
 public enum SelectionCacheType {
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionCacheType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionCacheType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,14 @@
 
 package org.optaplanner.core.config.heuristic.selector.common;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * There is no INHERIT by design because 2 sequential caches provides no benefit, only memory overhead.
  */
+@XmlType(name = "SelectionCacheTypeType") // TODO: think about XML type naming - TypeType
+@XmlEnum
 public enum SelectionCacheType {
     /**
      * Just in time, when the move is created. This is effectively no caching. This is the default for most selectors.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionOrder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionOrder.java
@@ -17,14 +17,13 @@
 package org.optaplanner.core.config.heuristic.selector.common;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
 
 /**
  * Defines in which order the elements or a selector are selected.
  */
-@XmlType(name = "SelectionOrderType")
+
 @XmlEnum
 public enum SelectionOrder {
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionOrder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/SelectionOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.optaplanner.core.config.heuristic.selector.common;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
 
 /**
  * Defines in which order the elements or a selector are selected.
  */
+@XmlType(name = "SelectionOrderType")
+@XmlEnum
 public enum SelectionOrder {
     /**
      * Inherit the value from the parent {@link SelectorConfig}. If the parent is cached,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
@@ -17,14 +17,13 @@
 package org.optaplanner.core.config.heuristic.selector.common.decorator;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 
 /**
  * @see SelectionSorter
  */
-@XmlType(name = "SelectionSorterOrderType")
+
 @XmlEnum
 public enum SelectionSorterOrder {
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.optaplanner.core.config.heuristic.selector.common.decorator;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 
 /**
  * @see SelectionSorter
  */
+@XmlType(name = "SelectionSorterOrderType")
+@XmlEnum
 public enum SelectionSorterOrder {
     /**
      * For example: 0, 1, 2, 3.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
@@ -53,6 +57,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "EntitySelectorType")
 @XStreamAlias("entitySelector")
 public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
 
@@ -62,8 +67,10 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
         return entitySelectorConfig;
     }
 
+    @XmlAttribute
     @XStreamAsAttribute
     protected String id = null;
+    @XmlAttribute
     @XStreamAsAttribute
     protected String mimicSelectorRef = null;
 
@@ -72,9 +79,11 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
     protected SelectionCacheType cacheType = null;
     protected SelectionOrder selectionOrder = null;
 
+    @XmlElement(name = "nearbySelection")
     @XStreamAlias("nearbySelection")
     protected NearbySelectionConfig nearbySelectionConfig = null;
 
+    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
     @XStreamImplicit(itemFieldName = "filterClass")
     protected List<Class<? extends SelectionFilter>> filterClassList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
@@ -57,7 +56,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "EntitySelectorType")
 @XStreamAlias("entitySelector")
 public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -54,7 +54,6 @@ import org.optaplanner.core.impl.heuristic.selector.entity.mimic.MimicReplayingE
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 @XStreamAlias("entitySelector")
 public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
@@ -81,9 +80,7 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
     @XStreamAlias("nearbySelection")
     protected NearbySelectionConfig nearbySelectionConfig = null;
 
-    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
-    @XStreamImplicit(itemFieldName = "filterClass")
-    protected List<Class<? extends SelectionFilter>> filterClassList = null;
+    protected Class<? extends SelectionFilter> filterClass = null;
 
     protected EntitySorterManner sorterManner = null;
     protected Class<? extends Comparator> sorterComparatorClass = null;
@@ -156,12 +153,12 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
         this.nearbySelectionConfig = nearbySelectionConfig;
     }
 
-    public List<Class<? extends SelectionFilter>> getFilterClassList() {
-        return filterClassList;
+    public Class<? extends SelectionFilter> getFilterClass() {
+        return filterClass;
     }
 
-    public void setFilterClassList(List<Class<? extends SelectionFilter>> filterClassList) {
-        this.filterClassList = filterClassList;
+    public void setFilterClass(Class<? extends SelectionFilter> filterClass) {
+        this.filterClass = filterClass;
     }
 
     public EntitySorterManner getSorterManner() {
@@ -296,7 +293,7 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
                 || cacheType != null
                 || selectionOrder != null
                 || nearbySelectionConfig != null
-                || filterClassList != null
+                || filterClass != null
                 || sorterManner != null
                 || sorterComparatorClass != null
                 || sorterWeightFactoryClass != null
@@ -356,20 +353,16 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
     }
 
     private boolean hasFiltering(EntityDescriptor entityDescriptor) {
-        return !ConfigUtils.isEmptyCollection(filterClassList)
-                || entityDescriptor.hasEffectiveMovableEntitySelectionFilter();
+        return filterClass != null || entityDescriptor.hasEffectiveMovableEntitySelectionFilter();
     }
 
     private EntitySelector applyFiltering(SelectionCacheType resolvedCacheType, SelectionOrder resolvedSelectionOrder,
             EntitySelector entitySelector) {
         EntityDescriptor entityDescriptor = entitySelector.getEntityDescriptor();
         if (hasFiltering(entityDescriptor)) {
-            List<SelectionFilter> filterList = new ArrayList<>(
-                    filterClassList == null ? 1 : filterClassList.size() + 1);
-            if (filterClassList != null) {
-                for (Class<? extends SelectionFilter> filterClass : filterClassList) {
-                    filterList.add(ConfigUtils.newInstance(this, "filterClass", filterClass));
-                }
+            List<SelectionFilter> filterList = new ArrayList<>(filterClass == null ? 1 : 2);
+            if (filterClass != null) {
+                filterList.add(ConfigUtils.newInstance(this, "filterClass", filterClass));
             }
             // Filter out pinned entities
             if (entityDescriptor.hasEffectiveMovableEntitySelectionFilter()) {
@@ -559,8 +552,8 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
         nearbySelectionConfig = ConfigUtils.inheritConfig(nearbySelectionConfig, inheritedConfig.getNearbySelectionConfig());
         cacheType = ConfigUtils.inheritOverwritableProperty(cacheType, inheritedConfig.getCacheType());
         selectionOrder = ConfigUtils.inheritOverwritableProperty(selectionOrder, inheritedConfig.getSelectionOrder());
-        filterClassList = ConfigUtils.inheritOverwritableProperty(
-                filterClassList, inheritedConfig.getFilterClassList());
+        filterClass = ConfigUtils.inheritOverwritableProperty(
+                filterClass, inheritedConfig.getFilterClass());
         sorterManner = ConfigUtils.inheritOverwritableProperty(
                 sorterManner, inheritedConfig.getSorterManner());
         sorterComparatorClass = ConfigUtils.inheritOverwritableProperty(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.optaplanner.core.config.heuristic.selector.entity;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 
 /**
  * The manner of sorting {@link PlanningEntity} instances.
  */
+@XmlType(name = "EntitySorterMannerType")
+@XmlEnum
 public enum EntitySorterManner {
     NONE,
     DECREASING_DIFFICULTY,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
@@ -17,14 +17,13 @@
 package org.optaplanner.core.config.heuristic.selector.entity;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 
 /**
  * The manner of sorting {@link PlanningEntity} instances.
  */
-@XmlType(name = "EntitySorterMannerType")
+
 @XmlEnum
 public enum EntitySorterManner {
     NONE,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.heuristic.selector.entity;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -16,11 +16,9 @@
 
 package org.optaplanner.core.config.heuristic.selector.move;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
@@ -55,7 +53,6 @@ import org.optaplanner.core.impl.heuristic.selector.move.decorator.SelectedCount
 import org.optaplanner.core.impl.heuristic.selector.move.decorator.ShufflingMoveSelector;
 import org.optaplanner.core.impl.heuristic.selector.move.decorator.SortingMoveSelector;
 
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 
 /**
@@ -76,9 +73,7 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
     protected SelectionCacheType cacheType = null;
     protected SelectionOrder selectionOrder = null;
 
-    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
-    @XStreamImplicit(itemFieldName = "filterClass")
-    protected List<Class<? extends SelectionFilter>> filterClassList = null;
+    protected Class<? extends SelectionFilter> filterClass = null;
 
     protected Class<? extends Comparator> sorterComparatorClass = null;
     protected Class<? extends SelectionSorterWeightFactory> sorterWeightFactoryClass = null;
@@ -111,12 +106,12 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
         this.selectionOrder = selectionOrder;
     }
 
-    public List<Class<? extends SelectionFilter>> getFilterClassList() {
-        return filterClassList;
+    public Class<? extends SelectionFilter> getFilterClass() {
+        return filterClass;
     }
 
-    public void setFilterClassList(List<Class<? extends SelectionFilter>> filterClassList) {
-        this.filterClassList = filterClassList;
+    public void setFilterClass(Class<? extends SelectionFilter> filterClass) {
+        this.filterClass = filterClass;
     }
 
     public Class<? extends Comparator> getSorterComparatorClass() {
@@ -190,8 +185,8 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
         return this;
     }
 
-    public MoveSelectorConfig withFilterClassList(List<Class<? extends SelectionFilter>> filterClassList) {
-        this.filterClassList = filterClassList;
+    public MoveSelectorConfig withFilterClassList(Class<? extends SelectionFilter> filterClass) {
+        this.filterClass = filterClass;
         return this;
     }
 
@@ -328,17 +323,14 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
             SelectionCacheType minimumCacheType, boolean randomSelection);
 
     private boolean hasFiltering() {
-        return !ConfigUtils.isEmptyCollection(filterClassList);
+        return filterClass != null;
     }
 
     private MoveSelector applyFiltering(SelectionCacheType resolvedCacheType, SelectionOrder resolvedSelectionOrder,
             MoveSelector moveSelector) {
         if (hasFiltering()) {
-            List<SelectionFilter> filterList = new ArrayList<>(filterClassList.size());
-            for (Class<? extends SelectionFilter> filterClass : filterClassList) {
-                filterList.add(ConfigUtils.newInstance(this, "filterClass", filterClass));
-            }
-            moveSelector = new FilteringMoveSelector(moveSelector, filterList);
+            SelectionFilter selectionFilter = ConfigUtils.newInstance(this, "filterClass", filterClass);
+            moveSelector = new FilteringMoveSelector(moveSelector, selectionFilter);
         }
         return moveSelector;
     }
@@ -496,8 +488,7 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
     private void inheritCommon(MoveSelectorConfig inheritedConfig) {
         cacheType = ConfigUtils.inheritOverwritableProperty(cacheType, inheritedConfig.getCacheType());
         selectionOrder = ConfigUtils.inheritOverwritableProperty(selectionOrder, inheritedConfig.getSelectionOrder());
-        filterClassList = ConfigUtils.inheritOverwritableProperty(
-                filterClassList, inheritedConfig.getFilterClassList());
+        filterClass = ConfigUtils.inheritOverwritableProperty(filterClass, inheritedConfig.getFilterClass());
         sorterComparatorClass = ConfigUtils.inheritOverwritableProperty(
                 sorterComparatorClass, inheritedConfig.getSorterComparatorClass());
         sorterWeightFactoryClass = ConfigUtils.inheritOverwritableProperty(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -58,6 +62,8 @@ import com.thoughtworks.xstream.annotations.XStreamInclude;
 /**
  * General superclass for {@link ChangeMoveSelectorConfig}, etc.
  */
+@XmlType(name = "MoveSelectorType")
+@XmlSeeAlso({ ChangeMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class, UnionMoveSelectorConfig.class })
 @XStreamInclude({
         UnionMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class,
         ChangeMoveSelectorConfig.class, SwapMoveSelectorConfig.class,
@@ -71,6 +77,7 @@ public abstract class MoveSelectorConfig<C extends MoveSelectorConfig> extends S
     protected SelectionCacheType cacheType = null;
     protected SelectionOrder selectionOrder = null;
 
+    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
     @XStreamImplicit(itemFieldName = "filterClass")
     protected List<Class<? extends SelectionFilter>> filterClassList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/MoveSelectorConfig.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
@@ -62,7 +61,7 @@ import com.thoughtworks.xstream.annotations.XStreamInclude;
 /**
  * General superclass for {@link ChangeMoveSelectorConfig}, etc.
  */
-@XmlType(name = "MoveSelectorType")
+
 @XmlSeeAlso({ ChangeMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class, UnionMoveSelectorConfig.class })
 @XStreamInclude({
         UnionMoveSelectorConfig.class, CartesianProductMoveSelectorConfig.class,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -37,7 +36,6 @@ import org.optaplanner.core.impl.heuristic.selector.move.composite.CartesianProd
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "CartesianProductMoveSelectorType")
 @XStreamAlias("cartesianProductMoveSelector")
 public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<CartesianProductMoveSelectorConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/CartesianProductMoveSelectorConfig.java
@@ -21,9 +21,14 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
@@ -32,9 +37,15 @@ import org.optaplanner.core.impl.heuristic.selector.move.composite.CartesianProd
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "CartesianProductMoveSelectorType")
 @XStreamAlias("cartesianProductMoveSelector")
 public class CartesianProductMoveSelectorConfig extends MoveSelectorConfig<CartesianProductMoveSelectorConfig> {
 
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class),
+    })
     @XStreamImplicit()
     private List<MoveSelectorConfig> moveSelectorConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -21,9 +21,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.heuristic.HeuristicConfigPolicy;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.FixedSelectorProbabilityWeightFactory;
@@ -34,9 +39,15 @@ import org.optaplanner.core.impl.heuristic.selector.move.composite.UnionMoveSele
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "UnionMoveSelectorType")
 @XStreamAlias("unionMoveSelector")
 public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelectorConfig> {
 
+    @XmlElements({
+            @XmlElement(name = "unionMoveSelector", type = UnionMoveSelectorConfig.class),
+            @XmlElement(name = "cartesianProductMoveSelector", type = CartesianProductMoveSelectorConfig.class),
+            @XmlElement(name = "changeMoveSelector", type = ChangeMoveSelectorConfig.class),
+    })
     @XStreamImplicit()
     private List<MoveSelectorConfig> moveSelectorConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/UnionMoveSelectorConfig.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -39,7 +38,6 @@ import org.optaplanner.core.impl.heuristic.selector.move.composite.UnionMoveSele
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "UnionMoveSelectorType")
 @XStreamAlias("unionMoveSelector")
 public class UnionMoveSelectorConfig extends MoveSelectorConfig<UnionMoveSelectorConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/composite/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.heuristic.selector.move.composite;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
@@ -41,7 +40,6 @@ import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-@XmlType(name = "ChangeMoveSelectorType")
 @XStreamAlias("changeMoveSelector")
 public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelectorConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/ChangeMoveSelectorConfig.java
@@ -21,6 +21,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
@@ -38,11 +41,15 @@ import org.optaplanner.core.impl.heuristic.selector.value.ValueSelector;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+@XmlType(name = "ChangeMoveSelectorType")
 @XStreamAlias("changeMoveSelector")
 public class ChangeMoveSelectorConfig extends MoveSelectorConfig<ChangeMoveSelectorConfig> {
 
+    @XmlElement(name = "entitySelector")
     @XStreamAlias("entitySelector")
     private EntitySelectorConfig entitySelectorConfig = null;
+
+    @XmlElement(name = "valueSelector")
     @XStreamAlias("valueSelector")
     private ValueSelectorConfig valueSelectorConfig = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/generic/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.heuristic.selector.move.generic;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/move/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.heuristic.selector.move;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
@@ -67,7 +66,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-@XmlType(name = "ValueSelectorType")
 @XStreamAlias("valueSelector")
 public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -64,7 +64,6 @@ import org.optaplanner.core.impl.heuristic.selector.value.mimic.ValueMimicRecord
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 @XStreamAlias("valueSelector")
 public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
@@ -88,9 +87,7 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
     @XStreamAlias("nearbySelection")
     protected NearbySelectionConfig nearbySelectionConfig = null;
 
-    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
-    @XStreamImplicit(itemFieldName = "filterClass")
-    protected List<Class<? extends SelectionFilter>> filterClassList = null;
+    protected Class<? extends SelectionFilter> filterClass = null;
 
     protected ValueSorterManner sorterManner = null;
     protected Class<? extends Comparator> sorterComparatorClass = null;
@@ -171,12 +168,12 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
         this.nearbySelectionConfig = nearbySelectionConfig;
     }
 
-    public List<Class<? extends SelectionFilter>> getFilterClassList() {
-        return filterClassList;
+    public Class<? extends SelectionFilter> getFilterClass() {
+        return filterClass;
     }
 
-    public void setFilterClassList(List<Class<? extends SelectionFilter>> filterClassList) {
-        this.filterClassList = filterClassList;
+    public void setFilterClass(Class<? extends SelectionFilter> filterClass) {
+        this.filterClass = filterClass;
     }
 
     public ValueSorterManner getSorterManner() {
@@ -334,7 +331,7 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
                 || cacheType != null
                 || selectionOrder != null
                 || nearbySelectionConfig != null
-                || filterClassList != null
+                || filterClass != null
                 || sorterManner != null
                 || sorterComparatorClass != null
                 || sorterWeightFactoryClass != null
@@ -423,19 +420,16 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
     }
 
     private boolean hasFiltering(GenuineVariableDescriptor variableDescriptor) {
-        return !ConfigUtils.isEmptyCollection(filterClassList) || variableDescriptor.hasMovableChainedTrailingValueFilter();
+        return filterClass != null || variableDescriptor.hasMovableChainedTrailingValueFilter();
     }
 
     private ValueSelector applyFiltering(SelectionCacheType resolvedCacheType, SelectionOrder resolvedSelectionOrder,
             ValueSelector valueSelector) {
         GenuineVariableDescriptor variableDescriptor = valueSelector.getVariableDescriptor();
         if (hasFiltering(variableDescriptor)) {
-            List<SelectionFilter> filterList = new ArrayList<>(
-                    filterClassList == null ? 1 : filterClassList.size() + 1);
-            if (filterClassList != null) {
-                for (Class<? extends SelectionFilter> filterClass : filterClassList) {
-                    filterList.add(ConfigUtils.newInstance(this, "filterClass", filterClass));
-                }
+            List<SelectionFilter> filterList = new ArrayList<>(filterClass == null ? 1 : 2);
+            if (filterClass != null) {
+                filterList.add(ConfigUtils.newInstance(this, "filterClass", filterClass));
             }
             // Filter out pinned entities
             if (variableDescriptor.hasMovableChainedTrailingValueFilter()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 import org.optaplanner.core.config.heuristic.selector.SelectorConfig;
@@ -63,24 +67,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
+@XmlType(name = "ValueSelectorType")
 @XStreamAlias("valueSelector")
 public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
 
+    @XmlAttribute
     @XStreamAsAttribute
     protected String id = null;
+    @XmlAttribute
     @XStreamAsAttribute
     protected String mimicSelectorRef = null;
 
     protected Class<?> downcastEntityClass = null;
+    @XmlAttribute
     @XStreamAsAttribute // Works with a nested element input too, which is a BC req in 7.x, but undesired in 8.0
     protected String variableName = null;
 
     protected SelectionCacheType cacheType = null;
     protected SelectionOrder selectionOrder = null;
 
+    @XmlElement(name = "nearbySelection")
     @XStreamAlias("nearbySelection")
     protected NearbySelectionConfig nearbySelectionConfig = null;
 
+    @XmlElement(name = "filterClass") // TODO: keep the list or use just a single filter class?
     @XStreamImplicit(itemFieldName = "filterClass")
     protected List<Class<? extends SelectionFilter>> filterClassList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterManner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterManner.java
@@ -17,14 +17,13 @@
 package org.optaplanner.core.config.heuristic.selector.value;
 
 import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
 /**
  * The manner of sorting a values for a {@link PlanningVariable}.
  */
-@XmlType(name = "ValueSorterMannerType")
+
 @XmlEnum
 public enum ValueSorterManner {
     NONE,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
+@XmlAccessorType(value = XmlAccessType.FIELD)
 package org.optaplanner.core.config.heuristic.selector.value;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
@@ -16,6 +16,9 @@
 
 package org.optaplanner.core.config.phase;
 
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.exhaustivesearch.ExhaustiveSearchPhaseConfig;
@@ -33,6 +36,8 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 
+@XmlType(name = "phaseType")
+@XmlSeeAlso({ ConstructionHeuristicPhaseConfig.class })
 @XStreamInclude({
         CustomPhaseConfig.class,
         NoChangePhaseConfig.class,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/PhaseConfig.java
@@ -17,7 +17,6 @@
 package org.optaplanner.core.config.phase;
 
 import javax.xml.bind.annotation.XmlSeeAlso;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.config.AbstractConfig;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
@@ -36,7 +35,6 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 
-@XmlType(name = "phaseType")
 @XmlSeeAlso({ ConstructionHeuristicPhaseConfig.class })
 @XStreamInclude({
         CustomPhaseConfig.class,

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/phase/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.phase;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
@@ -33,6 +33,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
@@ -70,6 +76,8 @@ import com.thoughtworks.xstream.converters.ConversionException;
  * To read it from XML, use {@link #createFromXmlResource(String)}.
  * To build a {@link SolverFactory} with it, use {@link SolverFactory#create(SolverConfig)}.
  */
+@XmlRootElement(name = "solver")
+@XmlType(name = "solverType")
 @XStreamAlias("solver")
 public class SolverConfig extends AbstractConfig<SolverConfig> {
 
@@ -217,6 +225,7 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
 
     private static final Logger logger = LoggerFactory.getLogger(SolverConfig.class);
 
+    @XmlTransient
     @XStreamOmitField
     private ClassLoader classLoader = null;
 
@@ -242,6 +251,9 @@ public class SolverConfig extends AbstractConfig<SolverConfig> {
     @XStreamAlias("termination")
     private TerminationConfig terminationConfig;
 
+    @XmlElements({
+            @XmlElement(name = "constructionHeuristic", type = ConstructionHeuristicPhaseConfig.class)
+    })
     @XStreamImplicit()
     protected List<PhaseConfig> phaseConfigList = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/SolverConfig.java
@@ -37,7 +37,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.solver.Solver;
@@ -77,7 +76,7 @@ import com.thoughtworks.xstream.converters.ConversionException;
  * To build a {@link SolverFactory} with it, use {@link SolverFactory#create(SolverConfig)}.
  */
 @XmlRootElement(name = "solver")
-@XmlType(name = "solverType")
+
 @XStreamAlias("solver")
 public class SolverConfig extends AbstractConfig<SolverConfig> {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/package-info.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/package-info.java
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.config.heuristic.selector.value;
+@XmlAccessorType(value = XmlAccessType.FIELD)
+package org.optaplanner.core.config.solver;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
-
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-
-/**
- * The manner of sorting a values for a {@link PlanningVariable}.
- */
-@XmlType(name = "ValueSorterMannerType")
-@XmlEnum
-public enum ValueSorterManner {
-    NONE,
-    INCREASING_STRENGTH,
-    INCREASING_STRENGTH_IF_AVAILABLE,
-    DECREASING_STRENGTH,
-    DECREASING_STRENGTH_IF_AVAILABLE;
-}
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelector.java
@@ -17,7 +17,6 @@
 package org.optaplanner.core.impl.heuristic.selector.move.decorator;
 
 import java.util.Iterator;
-import java.util.List;
 
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionFilter;
@@ -30,14 +29,14 @@ import org.optaplanner.core.impl.score.director.ScoreDirector;
 public class FilteringMoveSelector extends AbstractMoveSelector {
 
     protected final MoveSelector childMoveSelector;
-    protected final List<SelectionFilter> filterList;
+    protected final SelectionFilter filter;
     protected final boolean bailOutEnabled;
 
     protected ScoreDirector scoreDirector = null;
 
-    public FilteringMoveSelector(MoveSelector childMoveSelector, List<SelectionFilter> filterList) {
+    public FilteringMoveSelector(MoveSelector childMoveSelector, SelectionFilter filter) {
         this.childMoveSelector = childMoveSelector;
-        this.filterList = filterList;
+        this.filter = filter;
         bailOutEnabled = childMoveSelector.isNeverEnding();
         phaseLifecycleSupport.addEventListener(childMoveSelector);
     }
@@ -120,7 +119,7 @@ public class FilteringMoveSelector extends AbstractMoveSelector {
     }
 
     protected boolean accept(ScoreDirector scoreDirector, Move move) {
-        for (SelectionFilter filter : filterList) {
+        if (filter != null) {
             if (!filter.accept(scoreDirector, move)) {
                 return false;
             }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/ConfigMarshallingTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/ConfigMarshallingTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.solver.io.XStreamConfigReader;
+
+public class ConfigMarshallingTest {
+    private static final String TEST_SOLVER_CONFIG = "testSolverConfig.xml";
+
+    private final Unmarshaller unmarshaller;
+    private final Marshaller marshaller;
+
+    public ConfigMarshallingTest() throws JAXBException {
+        JAXBContext jaxbContext = JAXBContext.newInstance(SolverConfig.class);
+        unmarshaller = jaxbContext.createUnmarshaller();
+        marshaller = jaxbContext.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+    }
+
+    @Test
+    public void solverConfigMarshalling() throws JAXBException, IOException {
+        SolverConfig jaxbSolverConfig = unmarshallSolverConfig(TEST_SOLVER_CONFIG);
+
+        // serialize and deserialize back
+        File tempFile = Files.createTempFile("jaxbSolverConfig", ".xml").toFile();
+        marshaller.marshal(jaxbSolverConfig, tempFile);
+        jaxbSolverConfig = (SolverConfig) unmarshaller.unmarshal(tempFile);
+
+        // compare with xstream TODO: replace by a comparison with a configuration object model created via API
+        SolverConfig xstreamSolverConfig = (SolverConfig) XStreamConfigReader.buildXStream().fromXML(tempFile);
+        Assertions.assertThat(jaxbSolverConfig).usingRecursiveComparison().isEqualTo(xstreamSolverConfig);
+    }
+
+    private SolverConfig unmarshallSolverConfig(String solverConfigResource) {
+        try (InputStream testSolverConfigStream = ConfigMarshallingTest.class.getResourceAsStream(TEST_SOLVER_CONFIG)) {
+            return (SolverConfig) unmarshaller.unmarshal(testSolverConfigStream);
+        } catch (IOException | JAXBException exception) {
+            throw new RuntimeException("Failed to read solver configuration resource " + solverConfigResource, exception);
+        }
+    }
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/decorator/FilteringMoveSelectorTest.java
@@ -23,9 +23,6 @@ import static org.mockito.Mockito.when;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.assertAllCodesOfMoveSelector;
 import static org.optaplanner.core.impl.testdata.util.PlannerAssert.verifyPhaseLifecycle;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.impl.heuristic.move.DummyMove;
@@ -64,8 +61,7 @@ public class FilteringMoveSelectorTest {
                 new DummyMove("a1"), new DummyMove("a2"), new DummyMove("a3"), new DummyMove("a4"));
 
         SelectionFilter<TestdataSolution, DummyMove> filter = (scoreDirector, move) -> !move.getCode().equals("a3");
-        List<SelectionFilter> filterList = Arrays.asList(filter);
-        MoveSelector moveSelector = new FilteringMoveSelector(childMoveSelector, filterList);
+        MoveSelector moveSelector = new FilteringMoveSelector(childMoveSelector, filter);
         if (cacheType.isCached()) {
             moveSelector = new CachingMoveSelector(moveSelector, cacheType, false);
         }

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/config/testSolverConfig.xml
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/config/testSolverConfig.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver>
+  <constructionHeuristic>
+    <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
+    <forager>
+      <pickEarlyType>FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD</pickEarlyType>
+    </forager>
+    <queuedEntityPlacer>
+      <entitySelector id="placerEntitySelector">
+        <entityClass>org.optaplanner.core.impl.testdata.domain.TestdataEntity</entityClass>
+        <cacheType>PHASE</cacheType>
+        <selectionOrder>SORTED</selectionOrder>
+        <sorterManner>DECREASING_DIFFICULTY</sorterManner>
+      </entitySelector>
+      <cartesianProductMoveSelector>
+        <changeMoveSelector>
+          <entitySelector mimicSelectorRef="placerEntitySelector"/>
+          <valueSelector variableName="subValue">
+            <downcastEntityClass>org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedEntity</downcastEntityClass>
+            <cacheType>PHASE</cacheType>
+            <selectionOrder>SORTED</selectionOrder>
+            <sorterManner>INCREASING_STRENGTH</sorterManner>
+          </valueSelector>
+        </changeMoveSelector>
+        <changeMoveSelector>
+          <entitySelector mimicSelectorRef="placerEntitySelector"/>
+          <valueSelector variableName="value">
+            <cacheType>PHASE</cacheType>
+            <selectionOrder>SORTED</selectionOrder>
+            <sorterManner>INCREASING_STRENGTH</sorterManner>
+          </valueSelector>
+        </changeMoveSelector>
+      </cartesianProductMoveSelector>
+    </queuedEntityPlacer>
+    <pooledEntityPlacer>
+      <changeMoveSelector/>
+    </pooledEntityPlacer>
+    <queuedValuePlacer>
+      <changeMoveSelector/>
+    </queuedValuePlacer>
+    <unionMoveSelector>
+      <changeMoveSelector/>
+    </unionMoveSelector>
+  </constructionHeuristic>
+</solver>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/testdata/domain/JaxbTestdataSolution.java
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/src/test/java/org/optaplanner/persistence/jaxb/impl/testdata/domain/JaxbTestdataSolution.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -35,7 +34,7 @@ import org.optaplanner.persistence.jaxb.api.score.buildin.simple.SimpleScoreJaxb
 
 @PlanningSolution
 @XmlRootElement
-@XmlType(propOrder = { "valueList", "entityList", "score" })
+
 public class JaxbTestdataSolution extends JaxbTestdataObject {
 
     public static SolutionDescriptor<JaxbTestdataSolution> buildSolutionDescriptor() {

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.3.2</version>
+          <version>1.4.1</version>
           <configuration>
             <groups>java.,javax.,org.,com.</groups>
             <staticGroups>*</staticGroups>


### PR DESCRIPTION
The first part of JAXB configuration, which covers the XML subtree(*) under `<constructionHeuristic/>`.

(*) it's difficult to draw a borderline what falls under CH and what does not. If we took every single element that might occur in the CH subtree, it would involve the majority of the configuration code. The remaining part of `<solverConfig/>` will follow in the next PR [1].

[1] https://issues.redhat.com/browse/PLANNER-2022.