### PR TITLE
PLANNER-2021 Remove remaining references to JUnit 4

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ class TestGenTestWriter {
             imports.add("java.io.File");
         }
         if (scoreDefinition != null) {
-            imports.add("org.junit.Assert");
+            imports.add("org.junit.jupiter.api.Assertions");
             imports.add(ScoreHolder.class.getCanonicalName());
             imports.add(scoreDefinition.getClass().getCanonicalName());
         }
@@ -158,7 +158,7 @@ class TestGenTestWriter {
         if (scoreEx != null) {
             sb
                     .append("        // This is the corrupted score, just to make sure the bug is reproducible\n")
-                    .append("        Assert.assertEquals(\"").append(scoreEx.getWorkingScore())
+                    .append("        Assertions.assertEquals(\"").append(scoreEx.getWorkingScore())
                     .append("\", scoreHolder.extractScore(0).toString());\n");
             // demonstrate the uncorrupted score
             sb
@@ -175,7 +175,7 @@ class TestGenTestWriter {
             }
             sb
                     .append("        kieSession.fireAllRules();\n")
-                    .append("        Assert.assertEquals(\"").append(scoreEx.getUncorruptedScore())
+                    .append("        Assertions.assertEquals(\"").append(scoreEx.getUncorruptedScore())
                     .append("\", scoreHolder.extractScore(0).toString());\n");
         }
         sb

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/AbstractScoreHolderTest.java
@@ -16,8 +16,8 @@
 
 package org.optaplanner.core.impl.score.buildin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -108,7 +108,7 @@ public abstract class AbstractScoreHolderTest {
 
     @Test
     public void constraintMatchTotalsNeverNull() {
-        assertNotNull(buildScoreHolder(true).getConstraintMatchTotals());
+        assertThat(buildScoreHolder(true).getConstraintMatchTotals()).isNotNull();
     }
 
     private AbstractScoreHolder<SimpleScore> buildScoreHolder(boolean constraintMatchEnabled) {

--- a/optaplanner-core/src/test/resources/org/optaplanner/core/impl/score/director/drools/testgen/TestGenWriterOutput.java
+++ b/optaplanner-core/src/test/resources/org/optaplanner/core/impl/score/director/drools/testgen/TestGenWriterOutput.java
@@ -1,7 +1,7 @@
 package org.optaplanner.testgen;
 
 import java.io.File;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -51,7 +51,7 @@ public class TestGenWriterOutput {
         //operation F #3
         kieSession.fireAllRules();
         // This is the corrupted score, just to make sure the bug is reproducible
-        Assert.assertEquals("1", scoreHolder.extractScore(0).toString());
+        Assertions.assertEquals("1", scoreHolder.extractScore(0).toString());
         kieSession = kieContainer.newKieSession();
         scoreHolder = new SimpleScoreDefinition().buildScoreHolder(true);
         kieSession.setGlobal("scoreHolder", scoreHolder);
@@ -60,6 +60,6 @@ public class TestGenWriterOutput {
         //operation I #0
         kieSession.insert(testdataValue_2);
         kieSession.fireAllRules();
-        Assert.assertEquals("0", scoreHolder.extractScore(0).toString());
+        Assertions.assertEquals("0", scoreHolder.extractScore(0).toString());
     }
 }

--- a/optaplanner-distribution/pom.xml
+++ b/optaplanner-distribution/pom.xml
@@ -50,11 +50,6 @@
                   <artifactId>hibernate-core</artifactId>
                   <version>${version.org.hibernate}</version>
                 </additionalDependency>
-                <additionalDependency>
-                  <groupId>junit</groupId>
-                  <artifactId>junit</artifactId>
-                  <version>${version.junit}</version>
-                </additionalDependency>
               </additionalDependencies>
             </configuration>
           </execution>

--- a/optaplanner-quickstarts/spring-boot-school-timetabling/pom.xml
+++ b/optaplanner-quickstarts/spring-boot-school-timetabling/pom.xml
@@ -86,12 +86,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- UI -->

--- a/optaplanner-test/pom.xml
+++ b/optaplanner-test/pom.xml
@@ -41,8 +41,8 @@
     </dependency>
     <!-- Testing -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope><!-- Intentional, because optaplanner-test is intended to be used a test scoped dependency. -->
     </dependency>
   </dependencies>

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/AbstractScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/AbstractScoreVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.optaplanner.test.impl.score;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;


### PR DESCRIPTION
JUnit 4 is still on the classpath. That will be only fixed when we stop depending on kie-parent.
